### PR TITLE
add archive only mode

### DIFF
--- a/cmd/rivet/main.go
+++ b/cmd/rivet/main.go
@@ -40,7 +40,7 @@ func main() {
 		fmt.Fprint(os.Stdout, "\n")
 	}
 
-	flag.StringVar(&mode, "m", "remote", "Pin mode, supports mode: local, remote")
+	flag.StringVar(&mode, "m", "remote", "Pin mode, supports mode: local, remote, archive")
 	flag.UintVar(&timeout, "timeout", 30, "Timeout for every input URL")
 	flag.StringVar(&host, "host", "localhost", "IPFS node address")
 	flag.IntVar(&port, "port", 5001, "IPFS node port")
@@ -94,7 +94,7 @@ func main() {
 			reqctx, cancel := context.WithTimeout(ctx, toc)
 			defer cancel()
 
-			r := &rivet.Shaft{Hold: opt}
+			r := &rivet.Shaft{Hold: opt, ArchiveOnly: mode == "archive"}
 			if dest, err := r.Wayback(reqctx, input); err != nil {
 				fmt.Fprintf(os.Stderr, "rivet: %v\n", err)
 			} else {

--- a/internal/obelisk/archiver.go
+++ b/internal/obelisk/archiver.go
@@ -64,6 +64,8 @@ type Archiver struct {
 	dlSemaphore *semaphore.Weighted
 
 	PinFunc ipfs.HandlerFunc
+
+	SingleFile bool
 }
 
 // Validate prepares Archiver to make sure its configurations
@@ -179,6 +181,10 @@ func (arc *Archiver) transform(uri string, content []byte) string {
 	if err != nil {
 		name = sanitize.BaseName(uri)
 		path = filepath.Join(arc.ResTempDir, name)
+	}
+
+	if arc.SingleFile {
+		return createDataURL(content, http.DetectContentType(content))
 	}
 
 	if err := ioutil.WriteFile(path, content, 0600); err != nil {

--- a/rivet.go
+++ b/rivet.go
@@ -25,42 +25,48 @@ import (
 type Shaft struct {
 	// Hold specifies which IPFS mode to pin data through.
 	Hold ipfs.Pinning
+
+	ArchiveOnly bool // Do not store file on any IPFS node, just archive
 }
 
 // Wayback uses IPFS to archive webpages.
 func (s *Shaft) Wayback(ctx context.Context, input *url.URL) (cid string, err error) {
 	var pinFunc ipfs.HandlerFunc
-	switch s.Hold.Mode {
-	case ipfs.Local:
-		pinFunc = func(_ ipfs.Pinner, i interface{}) (string, error) {
-			switch v := i.(type) {
-			case []byte:
-				return (&ipfs.Locally{Pinning: s.Hold}).Pin(v)
-			case string:
-				return (&ipfs.Locally{Pinning: s.Hold}).PinDir(v)
-			default:
-				return "", errors.New("unknown pin request")
+	if !s.ArchiveOnly {
+		switch s.Hold.Mode {
+		case ipfs.Local:
+			pinFunc = func(_ ipfs.Pinner, i interface{}) (string, error) {
+				switch v := i.(type) {
+				case []byte:
+					return (&ipfs.Locally{Pinning: s.Hold}).Pin(v)
+				case string:
+					return (&ipfs.Locally{Pinning: s.Hold}).PinDir(v)
+				default:
+					return "", errors.New("unknown pin request")
+				}
 			}
-		}
-	case ipfs.Remote:
-		pinFunc = func(_ ipfs.Pinner, i interface{}) (string, error) {
-			switch v := i.(type) {
-			case []byte:
-				return (&ipfs.Remotely{Pinning: s.Hold}).Pin(v)
-			case string:
-				return (&ipfs.Remotely{Pinning: s.Hold}).PinDir(v)
-			default:
-				return "", errors.New("unknown pin request")
+		case ipfs.Remote:
+			pinFunc = func(_ ipfs.Pinner, i interface{}) (string, error) {
+				switch v := i.(type) {
+				case []byte:
+					return (&ipfs.Remotely{Pinning: s.Hold}).Pin(v)
+				case string:
+					return (&ipfs.Remotely{Pinning: s.Hold}).PinDir(v)
+				default:
+					return "", errors.New("unknown pin request")
+				}
 			}
+		default:
+			return "", errors.New("unknown pinning mode")
 		}
-	default:
-		return "", errors.New("unknown pinning mode")
 	}
 
-	dir := "rivet-" + sanitize.BaseName(input.Host) + sanitize.BaseName(input.Path)
+	name := sanitize.BaseName(input.Host) + sanitize.BaseName(input.Path)
+	dir := "rivet-" + name
 	if len(dir) > 255 {
 		dir = dir[:254]
 	}
+
 	dir, err = ioutil.TempDir(os.TempDir(), dir+"-")
 	if err != nil {
 		return "", errors.Wrap(err, "create temp directory failed: "+dir)
@@ -77,6 +83,8 @@ func (s *Shaft) Wayback(ctx context.Context, input *url.URL) (cid string, err er
 		ResTempDir: dir,
 
 		PinFunc: pinFunc,
+
+		SingleFile: s.ArchiveOnly,
 	}
 	arc.Validate()
 
@@ -84,10 +92,19 @@ func (s *Shaft) Wayback(ctx context.Context, input *url.URL) (cid string, err er
 	if err != nil {
 		return "", errors.Wrap(err, "archive failed")
 	}
+
 	// For auto indexing in IPFS, the filename should be index.html.
 	indexFile := filepath.Join(dir, "index.html")
+	if s.ArchiveOnly {
+		indexFile = name + ".html"
+	}
+
 	if err := ioutil.WriteFile(indexFile, content, 0600); err != nil {
 		return "", errors.Wrap(err, "create index file failed")
+	}
+
+	if s.ArchiveOnly {
+		return indexFile, nil
 	}
 
 	switch s.Hold.Mode {


### PR DESCRIPTION
... so we can do web archiving to a single html like obelisk (I know the internal/obelisk is like a fork, but the upstream had been dead for years https://github.com/go-shiori/obelisk/issues/2)

```sh
rivet -m archive https://mp.weixin.qq.com/s/wa98LIcSmoRz-1LxAfWZ9w

# mp-weixin-qq-com-s-wa98LIcSmoRz-1LxAfWZ9w.html  https://mp.weixin.qq.com/s/wa98LIcSmoRz-1LxAfWZ9w
```