### PR TITLE
use url.Parse instead of url.ParseRequestURI

### DIFF
--- a/internal/obelisk/archiver.go
+++ b/internal/obelisk/archiver.go
@@ -2,11 +2,9 @@ package obelisk
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	nurl "net/url"
 	"os"
@@ -50,10 +48,9 @@ type Archiver struct {
 	DisableEmbeds bool
 	DisableMedias bool
 
+	Transport             http.RoundTripper
 	RequestTimeout        time.Duration
-	SkipTLSVerification   bool
 	MaxConcurrentDownload int64
-	DialContext           func(ctx context.Context, network, addr string) (net.Conn, error)
 	SkipResourceURLError  bool
 	ResTempDir            string // directory to stores resources
 
@@ -83,14 +80,14 @@ func (arc *Archiver) Validate() {
 
 	arc.isValidated = true
 	arc.dlSemaphore = semaphore.NewWeighted(arc.MaxConcurrentDownload)
+
+	if arc.Transport == nil {
+		arc.Transport = http.DefaultTransport
+	}
+
 	arc.httpClient = &http.Client{
-		Timeout: arc.RequestTimeout,
-		Transport: &http.Transport{
-			DialContext: arc.DialContext,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: arc.SkipTLSVerification, //nolint:gosec
-			},
-		},
+		Timeout:   arc.RequestTimeout,
+		Transport: arc.Transport,
 	}
 }
 

--- a/internal/obelisk/archiver.go
+++ b/internal/obelisk/archiver.go
@@ -170,7 +170,7 @@ func (arc *Archiver) downloadFile(url string, parentURL string) (*http.Response,
 	return resp, err
 }
 
-func (arc *Archiver) transform(uri string, content []byte) string {
+func (arc *Archiver) transform(uri string, content []byte, contentType string) string {
 	path, name, err := arc.file(uri)
 	if err != nil {
 		name = sanitize.BaseName(uri)
@@ -178,12 +178,18 @@ func (arc *Archiver) transform(uri string, content []byte) string {
 	}
 
 	if arc.SingleFile {
-		return createDataURL(content, http.DetectContentType(content))
+		if contentType == "" {
+			contentType = http.DetectContentType(content)
+		}
+		return createDataURL(content, contentType)
 	}
 
 	if err := ioutil.WriteFile(path, content, 0600); err != nil {
 		// Fallback to creating data URL
-		return createDataURL(content, http.DetectContentType(content))
+		if contentType == "" {
+			contentType = http.DetectContentType(content)
+		}
+		return createDataURL(content, contentType)
 	}
 
 	return filepath.Join(".", name)

--- a/internal/obelisk/archiver.go
+++ b/internal/obelisk/archiver.go
@@ -104,7 +104,7 @@ func (arc *Archiver) Archive(ctx context.Context, req Request) ([]byte, string, 
 		return nil, "", fmt.Errorf("request url is not specified")
 	}
 
-	url, err := nurl.ParseRequestURI(req.URL)
+	url, err := nurl.Parse(req.URL)
 	if err != nil || url.Scheme == "" || url.Hostname() == "" {
 		return nil, "", fmt.Errorf("url \"%s\" is not valid", req.URL)
 	}

--- a/internal/obelisk/process-css.go
+++ b/internal/obelisk/process-css.go
@@ -47,7 +47,7 @@ func (arc *Archiver) processCSS(ctx context.Context, input io.Reader, baseURL *n
 		g.Go(func() error {
 			cssURL := sanitizeStyleURL(url)
 			cssURL = createAbsoluteURL(cssURL, baseURL)
-			content, _, err := arc.processURL(ctx, cssURL, baseURL.String())
+			content, contentType, err := arc.processURL(ctx, cssURL, baseURL.String())
 			if err != nil && err != errSkippedURL {
 				return err
 			}
@@ -56,7 +56,7 @@ func (arc *Archiver) processCSS(ctx context.Context, input io.Reader, baseURL *n
 			if err == errSkippedURL {
 				result = `url("` + cssURL + `")`
 			} else {
-				result = `url("` + arc.transform(cssURL, content) + `")`
+				result = `url("` + arc.transform(cssURL, content, contentType) + `")`
 			}
 
 			mutex.Lock()

--- a/internal/obelisk/process-html.go
+++ b/internal/obelisk/process-html.go
@@ -465,14 +465,14 @@ func (arc *Archiver) processURLNode(ctx context.Context, node *html.Node, attrNa
 	}
 
 	url := dom.GetAttribute(node, attrName)
-	content, _, err := arc.processURL(ctx, url, baseURL.String())
+	content, contentType, err := arc.processURL(ctx, url, baseURL.String())
 	if err != nil && err != errSkippedURL {
 		return err
 	}
 
 	newURL := url
 	if err == nil {
-		newURL = arc.transform(url, content)
+		newURL = arc.transform(url, content, contentType)
 	}
 
 	dom.SetAttribute(node, attrName, newURL)
@@ -509,7 +509,7 @@ func (arc *Archiver) processLinkNode(ctx context.Context, node *html.Node, baseU
 	}
 
 	url := dom.GetAttribute(node, "href")
-	content, _, err := arc.processURL(ctx, url, baseURL.String())
+	content, contentType, err := arc.processURL(ctx, url, baseURL.String())
 	if err != nil {
 		if err == errSkippedURL {
 			return nil
@@ -517,7 +517,7 @@ func (arc *Archiver) processLinkNode(ctx context.Context, node *html.Node, baseU
 		return err
 	}
 
-	newSrc := arc.transform(url, content)
+	newSrc := arc.transform(url, content, contentType)
 	dom.SetAttribute(node, "href", newSrc)
 
 	return nil
@@ -529,7 +529,7 @@ func (arc *Archiver) processScriptNode(ctx context.Context, node *html.Node, bas
 	}
 
 	url := dom.GetAttribute(node, "src")
-	content, _, err := arc.processURL(ctx, url, baseURL.String())
+	content, contentType, err := arc.processURL(ctx, url, baseURL.String())
 	if err != nil {
 		if err == errSkippedURL {
 			return nil
@@ -537,7 +537,7 @@ func (arc *Archiver) processScriptNode(ctx context.Context, node *html.Node, bas
 		return err
 	}
 
-	newSrc := arc.transform(url, content)
+	newSrc := arc.transform(url, content, contentType)
 	dom.SetAttribute(node, "src", newSrc)
 	return nil
 }
@@ -553,14 +553,14 @@ func (arc *Archiver) processEmbedNode(ctx context.Context, node *html.Node, base
 	}
 
 	url := dom.GetAttribute(node, attrName)
-	content, _, err := arc.processURL(ctx, url, baseURL.String())
+	content, contentType, err := arc.processURL(ctx, url, baseURL.String())
 	if err != nil && err != errSkippedURL {
 		return err
 	}
 
 	newURL := url
 	if err == nil {
-		newURL = arc.transform(url, content)
+		newURL = arc.transform(url, content, contentType)
 	}
 
 	dom.SetAttribute(node, attrName, newURL)
@@ -588,14 +588,14 @@ func (arc *Archiver) processMediaNode(ctx context.Context, node *html.Node, base
 		oldURL := parts[1]
 		targetWidth := parts[2]
 
-		content, _, err := arc.processURL(ctx, oldURL, baseURL.String())
+		content, contentType, err := arc.processURL(ctx, oldURL, baseURL.String())
 		if err != nil && err != errSkippedURL {
 			return err
 		}
 
 		newSet := oldURL
 		if err == nil {
-			newSet = arc.transform(oldURL, content)
+			newSet = arc.transform(oldURL, content, contentType)
 		}
 
 		newSet += targetWidth


### PR DESCRIPTION
`ParseRequestURI` will not handle the  [URI fragment](https://en.wikipedia.org/wiki/URI_fragment) correctly.

```go
url.ParseRequestURI("https://v2ex.com/t/831987#reply0")
// https://v2ex.com/t/831987%23reply0


url.Parse("https://v2ex.com/t/831987#reply0")
// https://v2ex.com/t/831987#reply0
```